### PR TITLE
Updates dependencies for Laravel 12 compatibility

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
-github: Muhammad Sajedul Karim
+github: ['skn-036', 'alexstewartja']
+buy_me_a_coffee: 'alexstewartja'

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
     "name": "skn036/laravel-google-client",
-    "version": "1.0.12",
+    "version": "1.1.0",
     "description": "Wrapper for Google API Client Library for Laravel",
     "keywords": [
-        "Muhammad Sajedul Karim",
         "laravel",
-        "laravel-google-client"
+        "google",
+        "oauth",
+        "client"
     ],
     "homepage": "https://github.com/skn036/laravel-google-client",
     "license": "MIT",
@@ -14,24 +15,30 @@
             "name": "Muhammad Sajedul Karim",
             "email": "noman0703036@gmail.com",
             "role": "Developer"
+        },
+        {
+            "name": "Alex Stewart",
+            "email": "iamalexstewart@gmail.com",
+            "role": "Developer"
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.2||^8.3||^8.4",
         "google/apiclient": "^2.17.0",
-        "illuminate/contracts": "^10||^11"
+        "illuminate/contracts": "^10||^11||^12.1.1"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "larastan/larastan": "^2.9",
-        "orchestra/testbench": "^9.0.0||^8.22.0",
-        "pestphp/pest": "^2.34",
-        "pestphp/pest-plugin-arch": "^2.7",
-        "pestphp/pest-plugin-laravel": "^2.3",
+        "nunomaduro/collision": "^7.10.0||^8.1.1",
+        "larastan/larastan": "^2.9||^3.0",
+        "orchestra/testbench": "^8.22.0||^9.0.0||^10.0.0",
+        "pestphp/pest": "^2.34||^3.0",
+        "pestphp/pest-plugin-arch": "^2.7||^3.0",
+        "pestphp/pest-plugin-laravel": "^2.3||^3.0",
         "phpstan/extension-installer": "^1.3",
-        "phpstan/phpstan-deprecation-rules": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.3"
+        "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
+        "phpstan/phpstan-phpunit": "^1.3||^2.0",
+        "roave/security-advisories": "dev-latest"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updates package dependencies to ensure compatibility with Laravel 12.

- Updates `illuminate/contracts`, `laravel/pint`, `nunomaduro/collision`, `larastan/larastan`, `orchestra/testbench`, `pestphp/pest`, `pestphp/pest-plugin-arch`, `pestphp/pest-plugin-laravel`, `phpstan/phpstan-deprecation-rules`, and `phpstan/phpstan-phpunit`.
- Adds support for PHP 8.3 and 8.4.